### PR TITLE
Correction for defined value of albedo_vis_dir

### DIFF
--- a/ocean_albedo.F90
+++ b/ocean_albedo.F90
@@ -392,7 +392,7 @@ if (ocean_albedo_option == 5) then
     albedo_vis_dir = 0.026/(coszen**1.7+0.065)                  &
                     +0.15*(coszen-0.10)*(coszen-0.5)*(coszen-1.0)
   elsewhere
-    albedo_vis_dir = 0.4075 ! coszen=0 value of above expression
+    albedo_vis_dir = 0.3925 ! coszen=0 value of above expression
   endwhere
   albedo_vis_dif = 0.06
   albedo_nir_dir = albedo_vis_dir


### PR DESCRIPTION
Changing value from 0.4075 to 0.3925

It's a segment of code that should never be exercised as coszen .ge. 0 should cover all contingencies. But you never know with roundoff to a negative value.

```Fortran
if (ocean_albedo_option == 5) then
   where (coszen .ge. 0.0)
     albedo_vis_dir = 0.026/(coszen**1.7+0.065)                  &
                     +0.15*(coszen-0.10)*(coszen-0.5)*(coszen-1.0)
   elsewhere
     albedo_vis_dir = 0.4075 ! coszen=0 value of above expression
   endwhere
   albedo_vis_dif = 0.06
   albedo_nir_dir = albedo_vis_dir
   albedo_nir_dif = 0.06
 endif
```

The "bug" is in the elsewhere segment where (if coszen=0)
albedo_vis_dif = 0.026/0.064 + 0.15*(-0.1)*(-0.5)*(-1)
= 0.4 + 0.15*(-0.05) = 0.4 - 0.0075 = 0.3925
I guess someone got confused by the triple negative.

My short test indicated no answer change.