### PR TITLE
bugfix for whitecap formula to be defined everywhere it is accessed

### DIFF
--- a/ocean_albedo.F90
+++ b/ocean_albedo.F90
@@ -421,6 +421,8 @@ if (ocean_albedo_option == 6) then
    where(ocean)
        ua=flux_u ! Note rough conversion from stress to speed
        va=flux_v ! Note rough conversion from stress to speed
+   elsewhere
+       ua=0.0; va=0.0 !To ensure working in debug mode
    endwhere
 
    call invert_tau_for_du(ua, va) ! Note rough conversion from stress to speed


### PR DESCRIPTION
- The variable was accessed where is was not defined (where not-ocean) leading to crash in debug mode in ESM4p2_amip